### PR TITLE
Update Wrapping for OculusSDK2

### DIFF
--- a/avango-oculus/include/avango/oculus/OculusWindow.hpp
+++ b/avango-oculus/include/avango/oculus/OculusWindow.hpp
@@ -3,7 +3,7 @@
 
 #include <gua/OculusWindow.hpp>
 
-#include <avango/gua/renderer/Window.hpp>
+#include <avango/gua/renderer/GlfwWindow.hpp>
 
 #include <gua/math/math.hpp>
 #include <avango/gua/Fields.hpp>
@@ -19,7 +19,7 @@ namespace av
     * Wrapper for ::gua::OculusWindow
     */
 
-    class AV_OCULUS_DLL OculusWindow : public av::gua::Window
+    class AV_OCULUS_DLL OculusWindow : public av::gua::GlfwWindow
     {
       AV_FC_DECLARE();
 
@@ -42,7 +42,6 @@ namespace av
          virtual ~OculusWindow();
 
        public:
-        //::av::SFString                      ProductName;
         ::av::gua::SFMatrix                 SensorOrientation;
         ::av::gua::SFVec2ui                 Resolution;
         ::av::gua::SFVec2ui                 EyeResolution;

--- a/avango-oculus/include/avango/oculus/OculusWindow.hpp
+++ b/avango-oculus/include/avango/oculus/OculusWindow.hpp
@@ -42,12 +42,15 @@ namespace av
          virtual ~OculusWindow();
 
        public:
-        ::av::SFString                      ProductName;
+        //::av::SFString                      ProductName;
         ::av::gua::SFMatrix                 SensorOrientation;
         ::av::gua::SFVec2ui                 Resolution;
         ::av::gua::SFVec2ui                 EyeResolution;
-        ::av::gua::SFVec2                   ScreenSize;
-        ::av::gua::SFVec2                   EyeScreenSize;
+        ::av::gua::SFVec2                   LeftScreenSize;
+        ::av::gua::SFVec2                   RightScreenSize;
+        ::av::gua::SFVec3                   LeftScreenTranslation;
+        ::av::gua::SFVec3                   RightScreenTranslation;
+        ::av::SFFloat                       EyeDistance;
 
        public:
          /**

--- a/avango-oculus/python/avango/oculus/OculusWindow.cpp
+++ b/avango-oculus/python/avango/oculus/OculusWindow.cpp
@@ -25,6 +25,6 @@ void init_OculusWindow()
 
   class_<av::oculus::OculusWindow,
        av::Link<av::oculus::OculusWindow>,
-       bases<av::gua::Window>, boost::noncopyable >("OculusWindow", "docstring", no_init)
+       bases<av::gua::GlfwWindow>, boost::noncopyable >("OculusWindow", "docstring", no_init)
         ;
 }

--- a/avango-oculus/src/avango/oculus/OculusWindow.cpp
+++ b/avango-oculus/src/avango/oculus/OculusWindow.cpp
@@ -20,22 +20,17 @@ AV_FIELD_DEFINE(av::oculus::MFOculusWindow);
 
 av::oculus::OculusWindow::OculusWindow(
   std::shared_ptr< ::gua::OculusWindow> const& guaOculusWindow
-) : av::gua::Window(guaOculusWindow),
+) : av::gua::GlfwWindow(guaOculusWindow),
     m_guaOculusWindow(guaOculusWindow)
 {
   // store hmd params in according fields
-  //AV_FC_ADD_FIELD(ProductName, m_guaOculusWindow->get_product_name());
   AV_FC_ADD_FIELD(SensorOrientation, ::gua::math::mat4());
-  //AV_FC_ADD_FIELD(Resolution, m_guaOculusWindow->get_resolution());
   AV_FC_ADD_FIELD(Resolution,m_guaOculusWindow->get_window_resolution());
   AV_FC_ADD_FIELD(EyeResolution,m_guaOculusWindow->get_window_resolution());
-  //AV_FC_ADD_FIELD(EyeResolution, m_guaOculusWindow->get_eye_resolution());
-  //AV_FC_ADD_FIELD(ScreenSize, m_guaOculusWindow->get_screen_size());
   AV_FC_ADD_FIELD(LeftScreenSize, m_guaOculusWindow->get_left_screen_size());
   AV_FC_ADD_FIELD(RightScreenSize, m_guaOculusWindow->get_right_screen_size());
   AV_FC_ADD_FIELD(LeftScreenTranslation, m_guaOculusWindow->get_left_screen_translation());
   AV_FC_ADD_FIELD(RightScreenTranslation, m_guaOculusWindow->get_right_screen_translation());
-  AV_FC_ADD_FIELD(EyeScreenSize, m_guaOculusWindow->get_screen_size_per_eye());
   AV_FC_ADD_FIELD(EyeDistance, m_guaOculusWindow->get_IPD());
 
 
@@ -53,9 +48,9 @@ av::oculus::OculusWindow::initClass()
 
   if (!isTypeInitialized())
   {
-    av::gua::Window::initClass();
+    av::gua::GlfwWindow::initClass();
 
-    AV_FC_INIT(av::gua::Window, av::oculus::OculusWindow, true);
+    AV_FC_INIT(av::gua::GlfwWindow, av::oculus::OculusWindow, true);
 
     SFOculusWindow::initClass("av::oculus::SFOculusWindow", "av::Field");
     MFOculusWindow::initClass("av::oculus::MFOculusWindow", "av::Field");
@@ -70,5 +65,5 @@ av::oculus::OculusWindow::getGuaOculusWindow() const {
 void
 av::oculus::OculusWindow::evaluate()
 {
-  SensorOrientation.setValue(m_guaOculusWindow->get_sensor_orientation());
+  SensorOrientation.setValue(m_guaOculusWindow->get_oculus_sensor_orientation());
 }

--- a/avango-oculus/src/avango/oculus/OculusWindow.cpp
+++ b/avango-oculus/src/avango/oculus/OculusWindow.cpp
@@ -24,12 +24,21 @@ av::oculus::OculusWindow::OculusWindow(
     m_guaOculusWindow(guaOculusWindow)
 {
   // store hmd params in according fields
-  AV_FC_ADD_FIELD(ProductName, m_guaOculusWindow->get_product_name());
+  //AV_FC_ADD_FIELD(ProductName, m_guaOculusWindow->get_product_name());
   AV_FC_ADD_FIELD(SensorOrientation, ::gua::math::mat4());
-  AV_FC_ADD_FIELD(Resolution, m_guaOculusWindow->get_resolution());
-  AV_FC_ADD_FIELD(EyeResolution, m_guaOculusWindow->get_eye_resolution());
-  AV_FC_ADD_FIELD(ScreenSize, m_guaOculusWindow->get_screen_size());
+  //AV_FC_ADD_FIELD(Resolution, m_guaOculusWindow->get_resolution());
+  AV_FC_ADD_FIELD(Resolution,m_guaOculusWindow->get_window_resolution());
+  AV_FC_ADD_FIELD(EyeResolution,m_guaOculusWindow->get_window_resolution());
+  //AV_FC_ADD_FIELD(EyeResolution, m_guaOculusWindow->get_eye_resolution());
+  //AV_FC_ADD_FIELD(ScreenSize, m_guaOculusWindow->get_screen_size());
+  AV_FC_ADD_FIELD(LeftScreenSize, m_guaOculusWindow->get_left_screen_size());
+  AV_FC_ADD_FIELD(RightScreenSize, m_guaOculusWindow->get_right_screen_size());
+  AV_FC_ADD_FIELD(LeftScreenTranslation, m_guaOculusWindow->get_left_screen_translation());
+  AV_FC_ADD_FIELD(RightScreenTranslation, m_guaOculusWindow->get_right_screen_translation());
   AV_FC_ADD_FIELD(EyeScreenSize, m_guaOculusWindow->get_screen_size_per_eye());
+  AV_FC_ADD_FIELD(EyeDistance, m_guaOculusWindow->get_IPD());
+
+
 
   // needs to evaluate every frame to update sensor orientation
   alwaysEvaluate(true);

--- a/examples/oculus/main.py
+++ b/examples/oculus/main.py
@@ -57,8 +57,32 @@ def start():
         Transform=(avango.gua.make_trans_mat(1, 1, 5) *
                    avango.gua.make_scale_mat(30, 30, 30))
         )
-
+    
     window = avango.oculus.nodes.OculusWindow()
+
+    #notice, that the oculus screen transforms and translations are automatically
+    #computed by the oculus. do not try to enter them yourself, or you will
+    #most likely get a wrong result due to influence of the lenses
+
+    #accessible fields:
+    #    SensorOrientation ##head pose (rotation and translation)
+    #    Resolution ##window resolution
+    #    EyeResolution ##recommended eye resolution (behaves strange so far)
+    #    LeftScreenSize  ## size of left screen in meters
+    #    RightScreenSize ## size of right screen in meters
+    #    LeftScreenTranslation  ## translation of left screen in meters
+    #    RightScreenTranslation ## translation of right screen in meters 
+    #    EyeDistance ## distance between both eyes in meters. for SDKs < v0.6, this is fixed to 0.064
+
+    # start the window in fullscreen and with the oculus window as primary display in order to fit the
+    # window nicely on the HMD
+    
+    window.Size.value = window.Resolution.value
+    window.LeftResolution.value = window.Resolution.value
+    window.RightResolution.value = window.Resolution.value
+    window.EnableFullscreen.value = True
+
+    
     avango.gua.register_window("window", window)
 
     cam = avango.gua.nodes.CameraNode(
@@ -67,7 +91,7 @@ def start():
         SceneGraph="scenegraph",
         Resolution=window.LeftResolution.value,
         OutputWindowName="window",
-        EyeDistance=0.064,
+        EyeDistance=window.EyeDistance.value,
         EnableStereo=True
         )
 
@@ -96,23 +120,22 @@ def start():
 
     cam.PipelineDescription.value = pipeline_description
 
-    eye_screen_distance = 0.08
 
     left_screen = avango.gua.nodes.ScreenNode(
         Name="left_screen",
-        Width=window.EyeScreenSize.value.x,
-        Height=window.EyeScreenSize.value.y,
+        Width=window.LeftScreenSize.value.x,
+        Height=window.LeftScreenSize.value.y,
         Transform=avango.gua.make_trans_mat(
-            -0.5 * window.EyeScreenSize.value.x, 0.0, -eye_screen_distance
+            window.LeftScreenTranslation.value
             )
         )
 
     right_screen = avango.gua.nodes.ScreenNode(
         Name="right_screen",
-        Width=window.EyeScreenSize.value.x,
-        Height=window.EyeScreenSize.value.y,
+        Width=window.RightScreenSize.value.x,
+        Height=window.RightScreenSize.value.y,
         Transform=avango.gua.make_trans_mat(
-            0.5 * window.EyeScreenSize.value.x, 0.0, -eye_screen_distance
+            window.RightScreenTranslation.value
             )
         )
 

--- a/examples/oculus/start.sh
+++ b/examples/oculus/start.sh
@@ -11,8 +11,14 @@ LOCAL_AVANGO="$DIR/../../../avango"
 GUACAMOLE=/opt/guacamole/master
 AVANGO=/opt/avango/master
 
+echo "Starting Oculus Rift Daemon..."
+/opt/OculusSDK/currentSDK2/Service/OVRServer/Bin/Linux/x86_64/ReleaseStatic/ovrd&
+
+sleep 3
+echo "Done."
+
 # third party libs
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/boost/current/lib:/opt/openscenegraph/3.0.1/lib64/:/opt/zmq/current/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/boost/current/lib:/opt/openscenegraph/3.0.1/lib64/:/opt/zmq/current/lib:/opt/pbr/inst_cb/lib:/opt/Awesomium/lib:/opt/OculusSDK/currentSDK2/LibOVR/Lib/Linux/x86_64/Release
 
 # schism
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/schism/current/lib/linux_x86


### PR DESCRIPTION
- adjust wrapping for new Oculus
- OculusWindow supports both SDK 1 and SDK 2
- viewing setup is calculated in the OculusWindow (do NOT measure the screen sizes on your own)
- update oculus example